### PR TITLE
chore: Update action display name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 # action.yml
-name: "exec-action"
+name: "Percy Exec"
 description: "A GitHub action to run `percy exec` CLI commands"
 branding:
   icon: 'camera'


### PR DESCRIPTION
## What is this?

This only updates the display name in the marketplace -- the API for installing an action uses the repo name. For example: https://github.com/marketplace/actions/automatic-revert 

Basically this would be the result: 
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/2072894/69747949-e788bf80-110c-11ea-9722-1d53a3284375.png">
