### PR TITLE
fix: Support scheduled jobs (or jobs without payloads)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+# on: [push, pull_request]
+on:
+  schedule:
+    # run every min, for testing
+    - cron:  '*/1 * * * *'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 # on: [push, pull_request]
 on:
   schedule:
-    # run every min, for testing
-    - cron:  '*/1 * * * *'
+    # run every 5 min, for testing
+    - cron:  '*/5 * * * *'
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/dist/index.js
+++ b/dist/index.js
@@ -8137,7 +8137,7 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
 // Sets the required env info for Percy to work correctly
 function setPercyBranchBuildInfo(pullRequestNumber) {
-  if (!github.context.payload) {
+  if (!!github.context.payload) {
     return;
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -8137,6 +8137,10 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
 // Sets the required env info for Percy to work correctly
 function setPercyBranchBuildInfo(pullRequestNumber) {
+  if (!github.context.payload) {
+    return;
+  }
+
   if (!!pullRequestNumber) {
     let prBranch = github.context.payload.pull_request.head.ref;
 
@@ -8885,7 +8889,7 @@ module.exports = {"activity":{"checkStarringRepo":{"method":"GET","params":{"own
 /***/ 731:
 /***/ (function(module) {
 
-module.exports = {"name":"exec","version":"0.1.1","description":"A GitHub action to run `percy exec` CLI commands for visual testing","main":"dist/index.js","repository":"https://github.com/percy/exec-action","keywords":["GitHub action","Percy","visual testing"],"author":"Perceptual Inc.","license":"MIT","scripts":{"build":"ncc build src/index.js","percy":"percy exec -- node ./tests/script.js","precommit":"yarn build && git add dist/index.js"},"dependencies":{"@actions/core":"^1.2.0","@actions/github":"^1.1.0","@percy/agent":"^0.19.5","@actions/exec":"^1.0.1","@actions/io":"^1.0.1"},"devDependencies":{"@percy/script":"^1.0.2","@zeit/ncc":"^0.20.5"}};
+module.exports = {"name":"exec","version":"0.1.2","description":"A GitHub action to run `percy exec` CLI commands for visual testing","main":"dist/index.js","repository":"https://github.com/percy/exec-action","keywords":["GitHub action","Percy","visual testing"],"author":"Perceptual Inc.","license":"MIT","scripts":{"build":"ncc build src/index.js","percy":"percy exec -- node ./tests/script.js","precommit":"yarn build && git add dist/index.js"},"dependencies":{"@actions/core":"^1.2.0","@actions/github":"^1.1.0","@percy/agent":"^0.19.5","@actions/exec":"^1.0.1","@actions/io":"^1.0.1"},"devDependencies":{"@percy/script":"^1.0.2","@zeit/ncc":"^0.20.5"}};
 
 /***/ }),
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
 // Sets the required env info for Percy to work correctly
 function setPercyBranchBuildInfo(pullRequestNumber) {
-  if (!github.context.payload) {
+  if (!!github.context.payload) {
     return;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
 // Sets the required env info for Percy to work correctly
 function setPercyBranchBuildInfo(pullRequestNumber) {
+  if (!github.context.payload) {
+    return;
+  }
+
   if (!!pullRequestNumber) {
     let prBranch = github.context.payload.pull_request.head.ref;
 


### PR DESCRIPTION
## What is this?

If you run scheduled jobs from actions, they don't have a payload associated with them. Right now this action needs a payload to run correctly, so this PR allows the action to gracefully run without that payload. 

It seems this job won't kick off unless it's on master? So I'll make another PR reverting the schedule after merge (and verifying this 100% does work). FWIW, it no longer errors when running locally:

<img width="536" alt="image" src="https://user-images.githubusercontent.com/2072894/72295361-02f84d00-361d-11ea-82c2-145cef3274bd.png">

See: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule