### PR TITLE
feat: Add `passthrough` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,31 @@ jobs:
         uses: actions/checkout@master
       - name: Install dependencies
         run: yarn
+      - name: Passthrough test
+        uses: ./
+        with:
+          passthrough: true
+      - name: Env test
+        run: |
+          node env-test.js LOG_LEVEL undefined
+          node env-test.js PERCY_BRANCH $(git rev-parse --abbrev-ref HEAD)
       - name: Default test
         uses: ./
         with:
           command: "node ./tests/script.js"
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      - name: Set debug env
+        uses: ./
+        with:
+          passthrough: true
+          verbose: true
+      - name: Debug env test
+        run: node env-test.js LOG_LEVEL debug
+      - name: Set silence env
+        uses: ./
+        with:
+          passthrough: true
+          silence: true
+      - name: Debug env test
+        run: node env-test.js LOG_LEVEL silence

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Tests
 on: [push, pull_request]
 jobs:
   build:
@@ -14,8 +14,8 @@ jobs:
           passthrough: true
       - name: Env test
         run: |
-          node env-test.js LOG_LEVEL undefined
-          node env-test.js PERCY_BRANCH $(git rev-parse --abbrev-ref HEAD)
+          node ./tests/env-test.js LOG_LEVEL
+          node ./tests/env-test.js PERCY_BRANCH $(git rev-parse --abbrev-ref HEAD)
       - name: Default test
         uses: ./
         with:
@@ -28,11 +28,11 @@ jobs:
           passthrough: true
           verbose: true
       - name: Debug env test
-        run: node env-test.js LOG_LEVEL debug
+        run: node ./tests/env-test.js LOG_LEVEL debug
       - name: Set silence env
         uses: ./
         with:
           passthrough: true
           silence: true
       - name: Debug env test
-        run: node env-test.js LOG_LEVEL silence
+        run: node ./tests/env-test.js LOG_LEVEL silence

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,16 @@
+name: PR Test
+on: pull_request
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Install dependencies
+        run: yarn
+      - name: Percy test
+        uses: ./
+        with:
+          command: "node ./tests/script.js"
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push, pull_request]
+on: push
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,7 +16,7 @@ jobs:
         run: |
           node ./tests/env-test.js LOG_LEVEL
           node ./tests/env-test.js PERCY_BRANCH $(git rev-parse --abbrev-ref HEAD)
-      - name: Default test
+      - name: Percy test
         uses: ./
         with:
           command: "node ./tests/script.js"

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,9 @@ inputs:
   working-directory:
     description: 'The directory for the commands to execute in'
     default: './'
+  passthrough:
+    description: 'Set Percy env vars, but do not execute commands'
+    default: false
   silence:
     description: 'Silence logging'
     default: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -8135,22 +8135,6 @@ const pkg = __webpack_require__(731);
 
 const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
-// Sets the required env info for Percy to work correctly
-function setPercyBranchBuildInfo(pullRequestNumber) {
-  if (!!github.context.payload) {
-    return;
-  }
-
-  if (!!pullRequestNumber) {
-    let prBranch = github.context.payload.pull_request.head.ref;
-
-    core.exportVariable('PERCY_BRANCH', prBranch);
-    core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
-  } else {
-    core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
-  }
-}
-
 (async () => {
   try {
     let flags = core.getInput('exec-flags');
@@ -8162,6 +8146,20 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let workingDir = core.getInput('working-directory');
     let pullRequestNumber = github.context.payload.number;
     let execOptions = { cwd: workingDir };
+
+    // Sets the required env info for Percy to work correctly
+    function setPercyBranchBuildInfo() {
+      if (!!pullRequestNumber) {
+        let prBranch = github.context.payload.pull_request.head.ref;
+
+        core.exportVariable('PERCY_BRANCH', prBranch);
+        core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
+      } else if (github.context.payload.ref) {
+        core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
+      } else {
+        if (isDebug) console.log('Could not set `PERCY_BRANCH`');
+      }
+    }
 
     // Set the CI builds user agent
     core.exportVariable('PERCY_GITHUB_ACTION', ACTION_UA);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8135,6 +8135,20 @@ const pkg = __webpack_require__(731);
 
 const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
+// Sets the required env info for Percy to work correctly
+function setPercyBranchBuildInfo(pullRequestNumber, isDebug) {
+  if (!!pullRequestNumber) {
+    let prBranch = github.context.payload.pull_request.head.ref;
+
+    core.exportVariable('PERCY_BRANCH', prBranch);
+    core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
+  } else if (github.context.payload.ref) {
+    core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
+  } else if (isDebug) {
+    console.log('Could not set `PERCY_BRANCH`');
+  }
+}
+
 (async () => {
   try {
     let flags = core.getInput('exec-flags');
@@ -8146,20 +8160,6 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
     let workingDir = core.getInput('working-directory');
     let pullRequestNumber = github.context.payload.number;
     let execOptions = { cwd: workingDir };
-
-    // Sets the required env info for Percy to work correctly
-    function setPercyBranchBuildInfo() {
-      if (!!pullRequestNumber) {
-        let prBranch = github.context.payload.pull_request.head.ref;
-
-        core.exportVariable('PERCY_BRANCH', prBranch);
-        core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
-      } else if (github.context.payload.ref) {
-        core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
-      } else {
-        if (isDebug) console.log('Could not set `PERCY_BRANCH`');
-      }
-    }
 
     // Set the CI builds user agent
     core.exportVariable('PERCY_GITHUB_ACTION', ACTION_UA);
@@ -8173,7 +8173,7 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
     }
 
     // Set the PR # (if available) and branch name
-    setPercyBranchBuildInfo(pullRequestNumber);
+    setPercyBranchBuildInfo(pullRequestNumber, isDebug);
 
     // Passthrough actions just set env vars,
     // running percy is done later in the workflow

--- a/dist/index.js
+++ b/dist/index.js
@@ -8157,6 +8157,7 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let testCommand = core.getInput('command');
     let customCommand = core.getInput('custom-command');
     let isDebug = core.getInput('verbose') === 'true';
+    let isPassthough = core.getInput('passthrough') === 'true';
     let isSilenced = core.getInput('silence') === 'true';
     let workingDir = core.getInput('working-directory');
     let pullRequestNumber = github.context.payload.number;
@@ -8175,6 +8176,10 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
 
     // Set the PR # (if available) and branch name
     setPercyBranchBuildInfo(pullRequestNumber);
+
+    // Passthrough actions just set env vars,
+    // running percy is done later in the workflow
+    if (isPassthough) return;
 
     if (customCommand) {
       // Run the passed command
@@ -8908,7 +8913,7 @@ module.exports = {"activity":{"checkStarringRepo":{"method":"GET","params":{"own
 /***/ 731:
 /***/ (function(module) {
 
-module.exports = {"name":"exec","version":"0.1.3","description":"A GitHub action to run `percy exec` CLI commands for visual testing","main":"dist/index.js","repository":"https://github.com/percy/exec-action","keywords":["GitHub action","Percy","visual testing"],"author":"Perceptual Inc.","license":"MIT","scripts":{"build":"ncc build src/index.js","percy":"percy exec -- node ./tests/script.js","precommit":"yarn build && git add dist/index.js"},"dependencies":{"@actions/core":"^1.2.0","@actions/github":"^1.1.0","@percy/agent":"^0.19.5","@actions/exec":"^1.0.3","@actions/io":"^1.0.2"},"devDependencies":{"@percy/script":"^1.0.2","@zeit/ncc":"^0.20.5"}};
+module.exports = {"name":"exec","version":"0.3.0","description":"A GitHub action to run `percy exec` CLI commands for visual testing","main":"dist/index.js","repository":"https://github.com/percy/exec-action","keywords":["GitHub action","Percy","visual testing"],"author":"Perceptual Inc.","license":"MIT","scripts":{"build":"ncc build src/index.js","percy":"percy exec -- node ./tests/script.js","precommit":"yarn build && git add dist/index.js"},"dependencies":{"@actions/core":"^1.2.0","@actions/github":"^1.1.0","@percy/agent":"^0.19.5","@actions/exec":"^1.0.3","@actions/io":"^1.0.2"},"devDependencies":{"@percy/script":"^1.0.2","@zeit/ncc":"^0.20.5"}};
 
 /***/ }),
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "exec",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A GitHub action to run `percy exec` CLI commands for visual testing",
   "main": "dist/index.js",
   "repository": "https://github.com/percy/exec-action",

--- a/src/index.js
+++ b/src/index.js
@@ -6,22 +6,6 @@ const pkg = require('../package.json');
 
 const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
-// Sets the required env info for Percy to work correctly
-function setPercyBranchBuildInfo(pullRequestNumber) {
-  if (!!github.context.payload) {
-    return;
-  }
-
-  if (!!pullRequestNumber) {
-    let prBranch = github.context.payload.pull_request.head.ref;
-
-    core.exportVariable('PERCY_BRANCH', prBranch);
-    core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
-  } else {
-    core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
-  }
-}
-
 (async () => {
   try {
     let flags = core.getInput('exec-flags');
@@ -33,6 +17,20 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let workingDir = core.getInput('working-directory');
     let pullRequestNumber = github.context.payload.number;
     let execOptions = { cwd: workingDir };
+
+    // Sets the required env info for Percy to work correctly
+    function setPercyBranchBuildInfo() {
+      if (!!pullRequestNumber) {
+        let prBranch = github.context.payload.pull_request.head.ref;
+
+        core.exportVariable('PERCY_BRANCH', prBranch);
+        core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
+      } else if (github.context.payload.ref) {
+        core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
+      } else {
+        if (isDebug) console.log('Could not set `PERCY_BRANCH`');
+      }
+    }
 
     // Set the CI builds user agent
     core.exportVariable('PERCY_GITHUB_ACTION', ACTION_UA);

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
     let testCommand = core.getInput('command');
     let customCommand = core.getInput('custom-command');
     let isDebug = core.getInput('verbose') === 'true';
+    let isPassthough = core.getInput('passthrough') === 'true';
     let isSilenced = core.getInput('silence') === 'true';
     let workingDir = core.getInput('working-directory');
     let pullRequestNumber = github.context.payload.number;
@@ -46,6 +47,10 @@ function setPercyBranchBuildInfo(pullRequestNumber) {
 
     // Set the PR # (if available) and branch name
     setPercyBranchBuildInfo(pullRequestNumber);
+
+    // Passthrough actions just set env vars,
+    // running percy is done later in the workflow
+    if (isPassthough) return;
 
     if (customCommand) {
       // Run the passed command

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,20 @@ const pkg = require('../package.json');
 
 const ACTION_UA = `${pkg.name}/${pkg.version}`;
 
+// Sets the required env info for Percy to work correctly
+function setPercyBranchBuildInfo(pullRequestNumber, isDebug) {
+  if (!!pullRequestNumber) {
+    let prBranch = github.context.payload.pull_request.head.ref;
+
+    core.exportVariable('PERCY_BRANCH', prBranch);
+    core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
+  } else if (github.context.payload.ref) {
+    core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
+  } else if (isDebug) {
+    console.log('Could not set `PERCY_BRANCH`');
+  }
+}
+
 (async () => {
   try {
     let flags = core.getInput('exec-flags');
@@ -17,20 +31,6 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
     let workingDir = core.getInput('working-directory');
     let pullRequestNumber = github.context.payload.number;
     let execOptions = { cwd: workingDir };
-
-    // Sets the required env info for Percy to work correctly
-    function setPercyBranchBuildInfo() {
-      if (!!pullRequestNumber) {
-        let prBranch = github.context.payload.pull_request.head.ref;
-
-        core.exportVariable('PERCY_BRANCH', prBranch);
-        core.exportVariable('PERCY_PULL_REQUEST', pullRequestNumber);
-      } else if (github.context.payload.ref) {
-        core.exportVariable('PERCY_BRANCH', github.context.payload.ref.replace('refs/heads/', ''));
-      } else {
-        if (isDebug) console.log('Could not set `PERCY_BRANCH`');
-      }
-    }
 
     // Set the CI builds user agent
     core.exportVariable('PERCY_GITHUB_ACTION', ACTION_UA);
@@ -44,7 +44,7 @@ const ACTION_UA = `${pkg.name}/${pkg.version}`;
     }
 
     // Set the PR # (if available) and branch name
-    setPercyBranchBuildInfo(pullRequestNumber);
+    setPercyBranchBuildInfo(pullRequestNumber, isDebug);
 
     // Passthrough actions just set env vars,
     // running percy is done later in the workflow

--- a/tests/env-test.js
+++ b/tests/env-test.js
@@ -1,0 +1,16 @@
+// Usage:
+// $ node env-test.js PERCY_BRANCH [current-brach]
+// $ node env-test.js PERCY_PULL_REQUEST [number]
+// $ node env-test.js LOG_LEVEL debug
+// $ node env-test.js LOG_LEVEL silence
+// $ node env-test.js PERCY_GITHUB_ACTION [UA]
+
+let [passedEnv, testValue] = process.argv.slice(2);
+let envVar = process.env[passedEnv];
+
+if (envVar !== testValue) {
+  console.error(`Expected: ${envVar} \nReceived: ${testValue}`);
+  process.exit(1);
+} else {
+  console.log('Passed!');
+}


### PR DESCRIPTION
## What is this?

This allows a user to use the exec-action to only set the Percy env vars. Then the user can run Percy however they wish _later_ in their workflow. Shout out to @agrobbin for the idea! 

I also took this chance to write a few env tests to ensure this is working properly (rather than relying on the Percy build) 